### PR TITLE
fix(ci): use bun in unit test pipeline

### DIFF
--- a/.github/workflows/pull_request_test.yml
+++ b/.github/workflows/pull_request_test.yml
@@ -14,22 +14,16 @@ jobs:
             - name: Checkout Repository
               uses: actions/checkout@v4
 
-            - name: Install pnpm
-              uses: pnpm/action-setup@v4
+            - name: Setup Bun
+              uses: oven-sh/setup-bun@v2
               with:
-                  version: 10.5.2
-
-            - name: Setup Node.js
-              uses: actions/setup-node@v4
-              with:
-                  node-version: 22.14 # Use the appropriate Node.js version
-                  cache: "pnpm" # Caches node_modules for faster runs
+                  bun-version: latest
 
             - name: Install Dependencies
-              run: pnpm install --frozen-lockfile
+              run: bun install --frozen-lockfile
 
             - name: Run Unit Tests
-              run: pnpm test:ci
+              run: bun run test:ci
 
     e2e-test:
         name: Run E2E Tests
@@ -40,6 +34,9 @@ jobs:
             - name: Checkout Repository
               uses: actions/checkout@v4
 
+            - name: Remove bun.lock file
+              run: rm bun.lock
+
             - name: Install pnpm
               uses: pnpm/action-setup@v4
               with:
@@ -49,10 +46,9 @@ jobs:
               uses: actions/setup-node@v4
               with:
                   node-version: 22.14
-                  cache: "pnpm"
 
             - name: Install Dependencies
-              run: pnpm install --frozen-lockfile
+              run: pnpm install
 
             - name: Install Cypress Binary
               run: pnpm cypress install

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
         "vite-tsconfig-paths": "^5.1.4",
         "vitest": "^3.0.7"
     },
-    "packageManager": "bun@1.2.0",
     "config": {
         "commitizen": {
             "path": "cz-conventional-changelog"


### PR DESCRIPTION
## Description
This update fixes the test pipeline and makes sure it runs perfectly

- it uses pnpm in the E2E tests because of a lack of support for the bun in cypress actions. 
- it uses bun for unit tests.
- make sure different package managers are usable