### PR TITLE
ci(github): ensure Envs are visible of forked PRs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,10 +1,13 @@
 name: Lint and Format Check
+permissions:
+  contents: read
 
 on:
   pull_request:
-    branches: [main, develop]
+    branches: [main]
+
   push:
-    branches: [main, develop]
+    branches: [main]
 
 jobs:
   lint:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,11 +1,11 @@
 name: Publish Docker Image
+permissions:
+  contents: read
 
 on:
   push:
-    tags:
-      - v*
-    branches:
-      - main
+    branches: ["main"]
+    tags: ["v*"]
 
 env:
   ENV_VARIABLES_FILE_DEVELOPMENT: ${{ vars.ENV_VARIABLES_FILE_DEVELOPMENT }}

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -1,4 +1,6 @@
 name: Semantic PR Validation
+permissions:
+  pull-requests: read
 
 on:
   pull_request_target:
@@ -7,9 +9,6 @@ on:
       - edited
       - synchronize
       - reopened
-
-permissions:
-  pull-requests: read
 
 jobs:
   validate-pr-title:
@@ -49,8 +48,7 @@ jobs:
 
       - name: Warn Missing Scope
         if: always() && !steps.lint_pr_title.outputs.scope
-        run:
-          echo "::warning ::The PR title does not include a scope. Consider
+        run: echo "::warning ::The PR title does not include a scope. Consider
           adding one for better clarity."
 
       - name: Remove Sticky Comment on Fix

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,13 +1,21 @@
 name: Testing
+permissions:
+  contents: read
 
 on:
-  push:
-    branches:
-      - main
+  # Using `pull_request_target` is a workaround for the issue where PRs from forks
+  # cannot access secrets or environment variables, as required in our workflow.
+  # To overcome this, we use `pull_request_target` and manually check out the source branch of the PR.
+  # See `actions/checkout` for how this is done.
+  # More info: https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
+  pull_request_target:
+    branches: [main]
 
   pull_request:
-    branches:
-      - main
+    branches: [main]
+
+  push:
+    branches: [main]
 
 env:
   ENV_VARIABLES_FILE_TEST: ${{ vars.ENV_VARIABLES_FILE_TEST }}
@@ -20,6 +28,9 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+        with:
+          # Ensure the workflow checks out the PR source branch (see explanation above)
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Add Test Environment Variables
         run: |
@@ -46,6 +57,9 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+        with:
+          # Ensure the workflow checks out the PR source branch (see explanation above)
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Add Test Environment Variables
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,8 +11,9 @@ on:
   pull_request_target:
     branches: [main]
 
-  pull_request:
-    branches: [main]
+  # This should be commented.
+  # pull_request:
+  #   branches: [main]
 
   push:
     branches: [main]


### PR DESCRIPTION
## Description

use of `pull_request_target` to safely expose envs in forked PRs
