### PR TITLE
update: the GraphQL mutation to match ezex-gateway

### DIFF
--- a/src/lib/graphql/mutations/send-confirmation-code.ts
+++ b/src/lib/graphql/mutations/send-confirmation-code.ts
@@ -4,7 +4,7 @@ import { gqlRequest, GQLRequestOptions } from "../client";
 export const SEND_CONFIRMATION_CODE = gql`
     mutation SendConfirmationCode($input: SendConfirmationCodeInput!) {
         sendConfirmationCode(input: $input) {
-            ok
+            recipient
         }
     }
 `;
@@ -22,6 +22,9 @@ export const sendConfirmationCodeAPI = async (
     body: SendConfirmationCodeAPIBody,
 ) => {
     return await gqlRequest(SEND_CONFIRMATION_CODE, {
-        input: body,
+        input: {
+            method: body.method,
+            recipient: body.recipient,
+        },
     });
 };

--- a/src/lib/graphql/mutations/verify-confirmation-code.ts
+++ b/src/lib/graphql/mutations/verify-confirmation-code.ts
@@ -4,7 +4,7 @@ import { gqlRequest, GQLRequestOptions } from "../client";
 export const VERIFY_CONFIRMATION_CODE = gql`
     mutation VerifyConfirmationCode($input: VerifyConfirmationCodeInput!) {
         verifyConfirmationCode(input: $input) {
-            ok
+            recipient
         }
     }
 `;
@@ -17,5 +17,10 @@ export interface VerifyConfirmationCodeAPIBody extends GQLRequestOptions {
 export const verifyConfirmationCodeAPI = async (
     body: VerifyConfirmationCodeAPIBody,
 ) => {
-    return await gqlRequest(VERIFY_CONFIRMATION_CODE, { input: body });
+    return await gqlRequest(VERIFY_CONFIRMATION_CODE, {
+        input: {
+            code: body.code,
+            recipient: body.recipient,
+        }
+    },);
 };


### PR DESCRIPTION
## Description

Incorrect GraphQL mutation return type (used ok instead of recipient).

Request body structure mismatch with backend SendConfirmationCodeInput schema.

## Related Issue

Fixes # (issue)
